### PR TITLE
Add Debug.Inspect

### DIFF
--- a/Debug.module.lua
+++ b/Debug.module.lua
@@ -327,4 +327,16 @@ do
 	end
 end
 
+--- Returns a string representation of anything.
+-- @param any Object The object you wish to represent as a string.
+-- @returns a readable string representation of the object.
+-- @author evaera
+function Debug.Inspect(Object)
+	if type(Object) == "table" then
+		return string.format("table %s", Debug.TableToString(Object))
+	else
+		return Debug.Stringify(Object)
+	end
+end
+
 return Table.Lock(Debug)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ string Debug.DirectoryToString (RbxObject Object)
 	// @param RbxObject Object the Object to get the directory of
 	// @returns string A readable and properly formatted string of the directory
 ```
+
+```cs
+string Debug.Inspect (any Object)
+	/// Returns a string representation of anything.
+	// @param any Object The object you wish to represent as a string.
+	// @returns a readable string representation of the object.
+```
 ```cs
 string Debug.EscapeString (string String)
 	/// Turns strings into Lua-readble format


### PR DESCRIPTION
Returns a string representation of anything so you can print out useful information while debugging without knowing the type of output.